### PR TITLE
Fixed incorrect fullPath in PboSub

### DIFF
--- a/PboFileDirectory.cpp
+++ b/PboFileDirectory.cpp
@@ -203,9 +203,10 @@ void PboFile::ReadFrom(std::filesystem::path inputPath)
                 curFolder = *subfolderFound;
                 continue;
             }
+
             auto newSub = std::make_shared<PboSubFolder>();
             newSub->filename = it;
-            newSub->fullPath = filePath.parent_path();
+            newSub->fullPath = curFolder->fullPath / it;
             newSub->rootFile = weak_from_this();
             curFolder->subfolders.emplace_back(std::move(newSub));
             curFolder = curFolder->subfolders.back();


### PR DESCRIPTION
If we have file Animations/Keyframe/test.sqf

we ended up with a folder named
Animations/Keyframe
when we should've only been creating the Animations one